### PR TITLE
Show biome features on the map (such as rivers, oceans, etc)

### DIFF
--- a/src/main/java/net/pl3x/bukkit/deathmaps/DeathMaps.java
+++ b/src/main/java/net/pl3x/bukkit/deathmaps/DeathMaps.java
@@ -32,6 +32,7 @@ public class DeathMaps extends JavaPlugin {
                 Location loc = player.getLocation();
                 BlockPosition pos = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
                 ItemStack nmsMap = ItemWorldMap.createFilledMapView(((CraftWorld) loc.getWorld()).getHandle(), pos.getX(), pos.getZ(), MapView.Scale.CLOSEST.getValue(), true, true);
+                ItemWorldMap.applySepiaFilter(((CraftWorld) loc.getWorld()).getHandle(), nmsMap);
                 WorldMap.decorateMap(nmsMap, pos, "Death", MapIcon.Type.TARGET_X);
                 NBTTagCompound displayTag = nmsMap.getOrCreateSubTag("display");
                 NBTTagList lore = new NBTTagList();


### PR DESCRIPTION
As it stands right now, the map is entirely blank when created (besides the cross showing the death point). This makes it somewhat more difficult to find where your stuff is since you can't see any of the surrounding details.

This PR will make it so the map also has the biome features displayed on the map, which looks a lot better than a blank map but might also help with discovering their death location better since they'll know what the surrounding area looks like.

Current Behavior:
![2020-01-10_01 45 59](https://user-images.githubusercontent.com/734478/72135933-3735ea00-334d-11ea-9961-91a8b9c0363f.png)

PR Behavior:
![2020-01-10_01 42 51](https://user-images.githubusercontent.com/734478/72135984-5a609980-334d-11ea-9def-94f304c90057.png)

I'm PRing this because I feel like it's an overall improvement that won't change your intended vision for the plugin. I plan on forking this project with many alterations for my own server fork, but felt like this change was beneficial to the parent project with no real downside.